### PR TITLE
Add missing "gulp-run-command" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "typescript": "^3.1.6",
     "gulp": "^3.9.1",
     "gulp-install": "^1.1.0",
+    "gulp-run-command": "0.0.9",
     "gulp-zip": "^4.2.0"
   },
   "scripts": {


### PR DESCRIPTION
The package "gulp-run-command" is needed for building the project via gulp but is currently missing.